### PR TITLE
Attempting to modify _meta schema for pmd data theme

### DIFF
--- a/schemas/pmd_meta.json
+++ b/schemas/pmd_meta.json
@@ -1,8 +1,8 @@
 {
   "fields": [
     {
-      "name": "title",
-      "title": "Title",
+      "name": "fileIdentifier",
+      "title": "Data theme unique identifier",
       "type": "string",
       "raises": "error",
       "constraints": {
@@ -10,8 +10,35 @@
       }
     },
     {
-      "name": "description",
+      "name": "InitiationDateStamp",
+      "title": "Date of project initiation",
+      "type": "string",
+      "raises": "error",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "title",
+      "title": "Program title",
+      "type": "string",
+      "raises": "error",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "abstract",
       "title": "Description",
+      "type": "string",
+      "raises": "error",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "purpose",
+      "title": "Purpose",
       "type": "string",
       "raises": "error",
       "constraints": {
@@ -28,16 +55,16 @@
       }
     },
     {
-      "name": "extents",
-      "title": "Extents",
+      "name": "EX_GeographicBoundingBox",
+      "title": "Geographic extents",
       "type": "string",
       "constraints": {
         "required": true
       }
     },
     {
-      "name": "citations",
-      "title": "Citations",
+      "name": "citation",
+      "title": "Data citation",
       "type": "string",
       "raises": "error",
       "constraints": {
@@ -45,8 +72,44 @@
       }
     },
     {
-      "name": "keywords",
+      "name": "descriptiveKeywords",
       "title": "Keywords",
+      "type": "string",
+      "raises": "error",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "organisationName",
+      "title": "Name of organization that collected data",
+      "type": "string",
+      "raises": "error",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "individualName",
+      "title": "Organizational contact name",
+      "type": "string",
+      "raises": "error",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "CI_Telephone",
+      "title": "Organizational contact phone number",
+      "type": "string",
+      "raises": "error",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "electronicMailAddress",
+      "title": "Organizational email address",
       "type": "string",
       "raises": "error",
       "constraints": {

--- a/schemas/pmd_meta.json
+++ b/schemas/pmd_meta.json
@@ -2,7 +2,7 @@
   "fields": [
     {
       "name": "fileIdentifier",
-      "title": "Data theme unique identifier",
+      "title": "Data theme unique id",
       "type": "string",
       "raises": "error",
       "constraints": {


### PR DESCRIPTION
Based on e-mail thread with Spencer Cox, Peter Pulsifer has attempted to add a number of metadata elements based on the Polar Data Catalogue (PDC) implementation of the ISO 19115 metadata standard.  See commit comments for more details.  Note that if accepted, these changes will not make the system ISO 19115 or PDC compliant, however it will move the system in that direction.  This work was based on a document provided by a project partner.  It is clear that that in that document there is a mix of data theme metadata (i.e. would apply to all samples), data sample metadata (i.e. different for each sample) and items that might be considered as part of the data rather than metadata (e.g. depth of sample).  
